### PR TITLE
Add notebooks for claim, KPI, and LLM evaluation workflows

### DIFF
--- a/01_claim_extraction.ipynb
+++ b/01_claim_extraction.ipynb
@@ -3,137 +3,84 @@
     {
       "cell_type": "markdown",
       "metadata": {},
-      "source": [
-        "# Claim-Extraktion mit ClimateBERT\n",
-        "\n",
-        "Dieses Notebook extrahiert potentielle Umweltaussagen aus ESG-Berichten mithilfe des in `src/greenwashing_pipeline/claim_extraction.py` implementierten ClimateBERT-Workflows. Die extrahierten Claims werden anschließend in einer CSV-Datei gespeichert, sodass sie im nächsten Schritt weiterverarbeitet werden können."
-      ]
+      "source": "# Claim Extraction\n\nThis notebook extracts environmental claims from sustainability reports using the `climatebert/environmental-claims` model."
     },
     {
       "cell_type": "markdown",
       "metadata": {},
-      "source": [
-        "## Voraussetzungen\n",
-        "- Python-Abhängigkeiten aus `requirements.txt` installieren (inkl. `transformers`, `torch`, `pdfplumber`, `pandas`).\n",
-        "- Die zu analysierenden Nachhaltigkeitsberichte (PDF) liegen im Ordner `ESG Reports` oder an einem frei wählbaren Pfad."
-      ]
+      "source": "## Setup\n\nInstall the required libraries if they are not available in your environment."
     },
     {
       "cell_type": "code",
       "metadata": {},
       "execution_count": null,
       "outputs": [],
-      "source": [
-        "from pathlib import Path\n",
-        "import pandas as pd\n",
-        "\n",
-        "# Stellt sicher, dass der `src`-Ordner importierbar ist\n",
-        "import sys\n",
-        "PROJECT_ROOT = Path.cwd()\n",
-        "SRC_DIR = PROJECT_ROOT / \"src\"\n",
-        "if str(SRC_DIR) not in sys.path:\n",
-        "    sys.path.insert(0, str(SRC_DIR))\n",
-        "\n",
-        "from greenwashing_pipeline.document_loader import PDFDocumentLoader\n",
-        "from greenwashing_pipeline.claim_extraction import ClaimExtractor"
-      ]
+      "source": "%pip install -q transformers accelerate torch pdfplumber pandas tqdm"
     },
     {
       "cell_type": "markdown",
       "metadata": {},
-      "source": [
-        "## Eingaben konfigurieren\n",
-        "Passe den `pdf_path` und den `output_csv` bei Bedarf an. Mit `max_pages` lässt sich die Seitenzahl zum Testen begrenzen."
-      ]
+      "source": "## Imports"
     },
     {
       "cell_type": "code",
       "metadata": {},
       "execution_count": null,
       "outputs": [],
-      "source": [
-        "pdf_path = Path(\"ESG Reports/sustainability-statement-2024.pdf.downloadasset.pdf\")\n",
-        "output_csv = Path(\"data/claims.csv\")\n",
-        "max_pages = 5  # auf `None` setzen, um das komplette Dokument zu verarbeiten\n",
-        "\n",
-        "output_csv.parent.mkdir(parents=True, exist_ok=True)\n",
-        "print(f\"PDF: {pdf_path}\")\n",
-        "print(f\"Claims werden gespeichert unter: {output_csv}\")"
-      ]
+      "source": "import json\nfrom pathlib import Path\nfrom typing import Dict, List\n\nimport pandas as pd\nimport pdfplumber\nfrom tqdm.auto import tqdm\nfrom transformers import AutoModelForSequenceClassification, AutoTokenizer, pipeline"
     },
     {
       "cell_type": "markdown",
       "metadata": {},
-      "source": [
-        "## PDF laden und in Abschnitte zerlegen"
-      ]
+      "source": "## Configuration\n\nAdjust the paths or thresholds below if needed."
     },
     {
       "cell_type": "code",
       "metadata": {},
       "execution_count": null,
       "outputs": [],
-      "source": [
-        "loader = PDFDocumentLoader(max_pages=max_pages)\n",
-        "sections = loader.load(pdf_path)\n",
-        "print(f\"Geladene Abschnitte: {len(sections)}\")\n",
-        "if sections:\n",
-        "    print(\"Erste Textpassage:\n",
-        "\", sections[0].text[:500])"
-      ]
+      "source": "ESG_REPORT_DIR = Path('ESG Reports')\nOUTPUT_CSV = Path('claims_extracted.csv')\nMODEL_NAME = 'climatebert/environmental-claims'\nMAX_TOKENS = 350\nSTRIDE = 50\nMIN_SCORE = 0.6"
     },
     {
       "cell_type": "markdown",
       "metadata": {},
-      "source": [
-        "## ClimateBERT-basierte Claim-Extraktion ausführen"
-      ]
+      "source": "## Helper Functions"
     },
     {
       "cell_type": "code",
       "metadata": {},
       "execution_count": null,
       "outputs": [],
-      "source": [
-        "claim_extractor = ClaimExtractor()\n",
-        "claims = claim_extractor.extract_from_sections(sections)\n",
-        "print(f\"Gefundene Claims: {len(claims)}\")"
-      ]
+      "source": "def iter_pdf_text(pdf_path: Path) -> List[str]:\n    \"\"\"Extract cleaned text chunks from a PDF file.\"\"\"\n    paragraphs: List[str] = []\n    with pdfplumber.open(pdf_path) as pdf:\n        for page in pdf.pages:\n            text = page.extract_text(x_tolerance=1, y_tolerance=1) or ''\n            segments = [seg.strip() for seg in text.split('\\n') if seg.strip()]\n            paragraphs.extend(segments)\n    return paragraphs\n\n\ndef chunk_text(paragraphs: List[str], max_tokens: int, stride: int, tokenizer) -> List[Dict[str, str]]:\n    \"\"\"Chunk text into overlapping windows for the transformer model.\"\"\"\n    encoded = tokenizer(paragraphs, padding=False, truncation=False, add_special_tokens=False)\n    chunks: List[Dict[str, str]] = []\n    current_tokens: List[int] = []\n    current_texts: List[str] = []\n    for text, token_ids in zip(paragraphs, encoded['input_ids']):\n        if len(current_tokens) + len(token_ids) > max_tokens:\n            if current_tokens:\n                chunks.append({'text': ' '.join(current_texts)})\n                if stride > 0:\n                    stride_tokens = current_tokens[-stride:]\n                    stride_text = tokenizer.decode(stride_tokens, skip_special_tokens=True)\n                    current_tokens = list(stride_tokens)\n                    current_texts = [stride_text]\n                else:\n                    current_tokens = []\n                    current_texts = []\n        current_tokens.extend(token_ids)\n        current_texts.append(text)\n    if current_tokens:\n        chunks.append({'text': ' '.join(current_texts)})\n    return chunks"
     },
     {
       "cell_type": "markdown",
       "metadata": {},
-      "source": [
-        "## Ergebnisse in ein DataFrame überführen und als CSV speichern"
-      ]
+      "source": "## Load Model"
     },
     {
       "cell_type": "code",
       "metadata": {},
       "execution_count": null,
       "outputs": [],
-      "source": [
-        "claims_df = pd.DataFrame([\n",
-        "    {\n",
-        "        \"document_id\": claim.document_id,\n",
-        "        \"page\": claim.page_number,\n",
-        "        \"label\": claim.label,\n",
-        "        \"score\": claim.score,\n",
-        "        \"text\": claim.text,\n",
-        "    }\n",
-        "    for claim in claims\n",
-        "])\n",
-        "\n",
-        "claims_df.to_csv(output_csv, index=False)\n",
-        "claims_df.head()"
-      ]
+      "source": "tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME)\nmodel = AutoModelForSequenceClassification.from_pretrained(MODEL_NAME)\nclaim_classifier = pipeline('text-classification', model=model, tokenizer=tokenizer, top_k=None, truncation=True)"
     },
     {
       "cell_type": "markdown",
       "metadata": {},
-      "source": [
-        "Die CSV-Datei dient als Eingabe für die LLM-Auswertung und kann bei Bedarf zusätzlich manuell annotiert werden."
-      ]
+      "source": "## Process Reports"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": "records = []\nfor pdf_path in sorted(ESG_REPORT_DIR.glob('*.pdf')):\n    paragraphs = iter_pdf_text(pdf_path)\n    chunks = chunk_text(paragraphs, max_tokens=MAX_TOKENS, stride=STRIDE, tokenizer=tokenizer)\n    for idx, chunk in enumerate(tqdm(chunks, desc=f'Processing {pdf_path.name}')):\n        text = chunk['text']\n        results = claim_classifier(text, truncation=True)\n        for result in results:\n            label = result['label']\n            score = float(result['score'])\n            if label.lower() == 'claim' and score >= MIN_SCORE:\n                records.append({\n                    'report': pdf_path.name,\n                    'chunk_id': idx,\n                    'text': text,\n                    'score': score,\n                })\n\nclaims_df = pd.DataFrame(records)\nclaims_df.to_csv(OUTPUT_CSV, index=False)\nclaims_df.head()"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": "## Save and Inspect\n\nThe full set of extracted claims is stored in `claims_extracted.csv`."
     }
   ],
   "metadata": {

--- a/02_kpi_extraction.ipynb
+++ b/02_kpi_extraction.ipynb
@@ -3,127 +3,72 @@
     {
       "cell_type": "markdown",
       "metadata": {},
-      "source": [
-        "# KPI-Extraktion aus Geschäftsberichten\n",
-        "\n",
-        "Dieses Notebook extrahiert Emissions- und Nachhaltigkeitskennzahlen aus PDF-Berichten mithilfe der Heuristiken aus `src/greenwashing_pipeline/kpi_extraction.py`. Die gefundenen Kennzahlen werden als CSV gespeichert und dienen später als Evidenz für das LLM."
-      ]
+      "source": "# KPI Extraction\n\nThis notebook extracts financial KPIs from annual reports and stores the results in a CSV file."
     },
     {
       "cell_type": "markdown",
       "metadata": {},
-      "source": [
-        "## Voraussetzungen\n",
-        "- Installation der Abhängigkeiten aus `requirements.txt` (u. a. `pdfplumber`, `pandas`).\n",
-        "- Die zu analysierenden Finanz- oder Geschäftsberichte liegen als PDF-Datei vor."
-      ]
+      "source": "## Setup"
     },
     {
       "cell_type": "code",
       "metadata": {},
       "execution_count": null,
       "outputs": [],
-      "source": [
-        "from pathlib import Path\n",
-        "import pandas as pd\n",
-        "\n",
-        "import sys\n",
-        "PROJECT_ROOT = Path.cwd()\n",
-        "SRC_DIR = PROJECT_ROOT / \"src\"\n",
-        "if str(SRC_DIR) not in sys.path:\n",
-        "    sys.path.insert(0, str(SRC_DIR))\n",
-        "\n",
-        "from greenwashing_pipeline.document_loader import PDFDocumentLoader\n",
-        "from greenwashing_pipeline.kpi_extraction import KPIExtractor"
-      ]
+      "source": "%pip install -q pdfplumber pandas regex"
     },
     {
       "cell_type": "markdown",
       "metadata": {},
-      "source": [
-        "## Eingaben konfigurieren\n",
-        "Passe `pdf_path`, `output_csv` und optional `max_pages` an deine Testdokumente an."
-      ]
+      "source": "## Imports"
     },
     {
       "cell_type": "code",
       "metadata": {},
       "execution_count": null,
       "outputs": [],
-      "source": [
-        "pdf_path = Path(\"Annual Reports/annual-report-2024.pdf.downloadasset.pdf\")\n",
-        "output_csv = Path(\"data/kpis.csv\")\n",
-        "max_pages = 5  # für vollständige Verarbeitung auf None setzen\n",
-        "\n",
-        "output_csv.parent.mkdir(parents=True, exist_ok=True)\n",
-        "print(f\"PDF: {pdf_path}\")\n",
-        "print(f\"KPI-Datei: {output_csv}\")"
-      ]
+      "source": "import re\nfrom pathlib import Path\nfrom typing import Dict, List\n\nimport pandas as pd\nimport pdfplumber"
     },
     {
       "cell_type": "markdown",
       "metadata": {},
-      "source": [
-        "## PDF laden und vorbereiten"
-      ]
+      "source": "## Configuration"
     },
     {
       "cell_type": "code",
       "metadata": {},
       "execution_count": null,
       "outputs": [],
-      "source": [
-        "loader = PDFDocumentLoader(max_pages=max_pages)\n",
-        "sections = loader.load(pdf_path)\n",
-        "print(f\"Geladene Abschnitte: {len(sections)}\")\n",
-        "if sections:\n",
-        "    print(\"Erste Textpassage:\n",
-        "\", sections[0].text[:500])"
-      ]
+      "source": "ANNUAL_REPORT_DIR = Path('Annual Reports')\nOUTPUT_CSV = Path('kpis_extracted.csv')\n\nKPI_PATTERNS = {\n    'revenue': r'(revenue|sales|turnover)[^0-9]+([0-9,.]+)',\n    'ebit': r'(ebit|operating profit)[^0-9]+([0-9,.]+)',\n    'net_income': r'(net income|profit attributable)[^0-9]+([0-9,.]+)',\n    'total_assets': r'(total assets)[^0-9]+([0-9,.]+)',\n    'scope_1_emissions': r'(scope\\s*1[^0-9]*emissions?)[^0-9]+([0-9,.]+)',\n    'scope_2_emissions': r'(scope\\s*2[^0-9]*emissions?)[^0-9]+([0-9,.]+)',\n}"
     },
     {
       "cell_type": "markdown",
       "metadata": {},
-      "source": [
-        "## KPIs extrahieren"
-      ]
+      "source": "## Helper Functions"
     },
     {
       "cell_type": "code",
       "metadata": {},
       "execution_count": null,
       "outputs": [],
-      "source": [
-        "kpi_extractor = KPIExtractor()\n",
-        "kpis = kpi_extractor.extract_from_sections(sections)\n",
-        "print(f\"Gefundene KPIs: {len(kpis)}\")"
-      ]
+      "source": "def extract_text_blocks(pdf_path: Path) -> List[str]:\n    blocks: List[str] = []\n    with pdfplumber.open(pdf_path) as pdf:\n        for page in pdf.pages:\n            text = page.extract_text(x_tolerance=1, y_tolerance=1) or ''\n            if text:\n                blocks.extend([line.strip() for line in text.split('\\n') if line.strip()])\n    return blocks\n\n\ndef find_kpis(blocks: List[str], patterns: Dict[str, str]) -> Dict[str, str]:\n    values: Dict[str, str] = {}\n    joined_text = '\\n'.join(blocks)\n    for kpi, pattern in patterns.items():\n        match = re.search(pattern, joined_text, flags=re.IGNORECASE)\n        if match:\n            values[kpi] = match.group(2).replace(',', '').strip()\n        else:\n            values[kpi] = ''\n    return values"
     },
     {
       "cell_type": "markdown",
       "metadata": {},
-      "source": [
-        "## Ergebnis speichern"
-      ]
+      "source": "## Process Reports"
     },
     {
       "cell_type": "code",
       "metadata": {},
       "execution_count": null,
       "outputs": [],
-      "source": [
-        "kpi_df = pd.DataFrame([kpi.to_dict() for kpi in kpis])\n",
-        "\n",
-        "kpi_df.to_csv(output_csv, index=False)\n",
-        "kpi_df.head()"
-      ]
+      "source": "records = []\nfor pdf_path in sorted(ANNUAL_REPORT_DIR.glob('*.pdf')):\n    blocks = extract_text_blocks(pdf_path)\n    kpi_values = find_kpis(blocks, KPI_PATTERNS)\n    kpi_values['report'] = pdf_path.name\n    records.append(kpi_values)\n\nkpis_df = pd.DataFrame(records)\nkpis_df.to_csv(OUTPUT_CSV, index=False)\nkpis_df.head()"
     },
     {
       "cell_type": "markdown",
       "metadata": {},
-      "source": [
-        "Die KPI-CSV dient als Grundlage für den DeepSeek-Abgleich mit den Claims."
-      ]
+      "source": "## Save and Inspect\n\nThe full set of extracted KPIs is saved in `kpis_extracted.csv`."
     }
   ],
   "metadata": {

--- a/03_llm_evaluation.ipynb
+++ b/03_llm_evaluation.ipynb
@@ -3,195 +3,108 @@
     {
       "cell_type": "markdown",
       "metadata": {},
-      "source": [
-        "# Konsistenzprüfung mit DeepSeek R1 Zero\n",
-        "\n",
-        "Dieses Notebook lädt die zuvor extrahierten Claims und KPIs, ruft DeepSeek R1 Zero über die OpenRouter-API auf und bewertet, ob die Aussagen durch die Kennzahlen gestützt oder widerlegt werden."
-      ]
+      "source": "# LLM Evaluation for Greenwashing Detection\n\nThis notebook combines extracted claims and KPIs to prompt an LLM and identify potential inconsistencies."
     },
     {
       "cell_type": "markdown",
       "metadata": {},
-      "source": [
-        "## Voraussetzungen\n",
-        "- Erfolgreich erzeugte CSV-Dateien aus den Notebooks `01_claim_extraction.ipynb` und `02_kpi_extraction.ipynb`.\n",
-        "- Ein gültiger OpenRouter API Key in der Umgebungsvariable `OPENROUTER_API_KEY`.\n",
-        "- Internetzugang zum Aufruf des Modells `deepseek/deepseek-r1-zero`."
-      ]
+      "source": "## Setup"
     },
     {
       "cell_type": "code",
       "metadata": {},
       "execution_count": null,
       "outputs": [],
-      "source": [
-        "from pathlib import Path\n",
-        "import json\n",
-        "import ast\n",
-        "import pandas as pd\n",
-        "from collections import defaultdict\n",
-        "import os\n",
-        "\n",
-        "import sys\n",
-        "PROJECT_ROOT = Path.cwd()\n",
-        "SRC_DIR = PROJECT_ROOT / \"src\"\n",
-        "if str(SRC_DIR) not in sys.path:\n",
-        "    sys.path.insert(0, str(SRC_DIR))\n",
-        "\n",
-        "from greenwashing_pipeline.claim_extraction import ClaimCandidate\n",
-        "from greenwashing_pipeline.kpi_extraction import KPIRecord\n",
-        "from greenwashing_pipeline.llm_evaluator import ConsistencyEvaluator"
-      ]
+      "source": "%pip install -q transformers accelerate pandas"
     },
     {
       "cell_type": "markdown",
       "metadata": {},
-      "source": [
-        "## Pfade und Optionen einstellen\n",
-        "Mit `run_evaluation` kann der API-Aufruf testweise deaktiviert werden."
-      ]
+      "source": "## Imports"
     },
     {
       "cell_type": "code",
       "metadata": {},
       "execution_count": null,
       "outputs": [],
-      "source": [
-        "claims_csv = Path(\"data/claims.csv\")\n",
-        "kpis_csv = Path(\"data/kpis.csv\")\n",
-        "output_json = Path(\"data/evaluations.json\")\n",
-        "run_evaluation = True  # auf False setzen, um DeepSeek nicht aufzurufen\n",
-        "\n",
-        "print(f\"Claims-CSV: {claims_csv}\")\n",
-        "print(f\"KPI-CSV: {kpis_csv}\")\n",
-        "print(f\"Ergebnis-JSON: {output_json}\")"
-      ]
+      "source": "from pathlib import Path\nfrom typing import Dict\n\nimport pandas as pd\nfrom transformers import AutoModelForCausalLM, AutoTokenizer, pipeline"
     },
     {
       "cell_type": "markdown",
       "metadata": {},
-      "source": [
-        "## CSV-Dateien laden und in Python-Objekte umwandeln"
-      ]
+      "source": "## Configuration"
     },
     {
       "cell_type": "code",
       "metadata": {},
       "execution_count": null,
       "outputs": [],
-      "source": [
-        "claims_df = pd.read_csv(claims_csv)\n",
-        "kpis_df = pd.read_csv(kpis_csv)\n",
-        "\n",
-        "claims = [\n",
-        "    ClaimCandidate(\n",
-        "        text=row[\"text\"],\n",
-        "        label=row[\"label\"],\n",
-        "        score=float(row[\"score\"]),\n",
-        "        document_id=row[\"document_id\"],\n",
-        "        page_number=int(row[\"page\"]),\n",
-        "    )\n",
-        "    for _, row in claims_df.iterrows()\n",
-        "]\n",
-        "\n",
-        "def parse_metadata(value):\n",
-        "    if isinstance(value, dict):\n",
-        "        return value\n",
-        "    if pd.isna(value):\n",
-        "        return {}\n",
-        "    try:\n",
-        "        return ast.literal_eval(value)\n",
-        "    except (ValueError, SyntaxError):\n",
-        "        return {}\n",
-        "\n",
-        "kpirecords = []\n",
-        "for _, row in kpis_df.iterrows():\n",
-        "    metadata = parse_metadata(row.get(\"metadata\"))\n",
-        "    kpirecords.append(\n",
-        "        KPIRecord(\n",
-        "            kpi_type=row[\"kpi_type\"],\n",
-        "            value=float(row[\"value\"]),\n",
-        "            unit=row.get(\"unit\") if not pd.isna(row.get(\"unit\")) else None,\n",
-        "            year=int(row[\"year\"]) if not pd.isna(row.get(\"year\")) else None,\n",
-        "            source_text=row.get(\"source_text\", \"\"),\n",
-        "            document_id=row[\"document_id\"],\n",
-        "            page_number=int(row[\"page_number\"]),\n",
-        "            metadata=metadata,\n",
-        "        )\n",
-        "    )\n",
-        "\n",
-        "print(f\"Claims geladen: {len(claims)}\")\n",
-        "print(f\"KPIs geladen: {len(kpirecords)}\")"
-      ]
+      "source": "CLAIMS_CSV = Path('claims_extracted.csv')\nKPIS_CSV = Path('kpis_extracted.csv')\nMODEL_NAME = 'deepseek-ai/DeepSeek-R1-Zero'\nMAX_NEW_TOKENS = 512"
     },
     {
       "cell_type": "markdown",
       "metadata": {},
-      "source": [
-        "## KPIs je Dokument bündeln"
-      ]
+      "source": "## Load Data"
     },
     {
       "cell_type": "code",
       "metadata": {},
       "execution_count": null,
       "outputs": [],
-      "source": [
-        "kpis_by_doc = defaultdict(list)\n",
-        "for kpi in kpirecords:\n",
-        "    kpis_by_doc[kpi.document_id].append(kpi)\n",
-        "\n",
-        "{doc: len(items) for doc, items in kpis_by_doc.items()}"
-      ]
+      "source": "claims_df = pd.read_csv(CLAIMS_CSV)\nkpis_df = pd.read_csv(KPIS_CSV)\n\nclaims_df.head(), kpis_df.head()"
     },
     {
       "cell_type": "markdown",
       "metadata": {},
-      "source": [
-        "## LLM-Auswertung anstoßen"
-      ]
+      "source": "## Prompt Construction"
     },
     {
       "cell_type": "code",
       "metadata": {},
       "execution_count": null,
       "outputs": [],
-      "source": [
-        "if run_evaluation:\n",
-        "    if not os.getenv(\"OPENROUTER_API_KEY\"):\n",
-        "        raise RuntimeError(\"OPENROUTER_API_KEY ist nicht gesetzt. Bitte vor dem Ausführen hinterlegen oder `run_evaluation = False` verwenden.\")\n",
-        "    evaluator = ConsistencyEvaluator()\n",
-        "    evaluations = []\n",
-        "    for claim in claims:\n",
-        "        doc_kpis = kpis_by_doc.get(claim.document_id, [])\n",
-        "        result = evaluator.evaluate(claim, doc_kpis)\n",
-        "        evaluations.append(result)\n",
-        "else:\n",
-        "    print(\"Evaluation übersprungen – es werden Dummy-Ergebnisse erzeugt.\")\n",
-        "    evaluations = []\n",
-        "\n",
-        "len(evaluations)"
-      ]
+      "source": "def build_prompt(claim_row: pd.Series, kpi_row: pd.Series) -> str:\n    claim_text = claim_row['text']\n    claim_score = claim_row.get('score', float('nan'))\n    kpi_values = kpi_row.drop(labels=['report']).to_dict()\n    kpi_lines = '\\n'.join(f\"- {name}: {value}\" for name, value in kpi_values.items() if value)\n    prompt = (\n        \"You are an ESG auditor. Analyse the sustainability claim against the financial indicators.\\n\\n\"\n        f\"Claim (confidence {claim_score:.2f}): {claim_text}\\n\\n\"\n        f\"Financial indicators from annual report:\\n{kpi_lines if kpi_lines else '- No KPIs found.'}\\n\\n\"\n        \"Assess whether the claim is supported by the KPIs, flag inconsistencies, and explain your reasoning.\"\n    )\n    return prompt"
     },
     {
       "cell_type": "markdown",
       "metadata": {},
-      "source": [
-        "## Ergebnisse speichern\n",
-        "Die DeepSeek-Antworten werden als JSON-Datei abgelegt und können anschließend analysiert oder visualisiert werden."
-      ]
+      "source": "## Load Model"
     },
     {
       "cell_type": "code",
       "metadata": {},
       "execution_count": null,
       "outputs": [],
-      "source": [
-        "payload = [evaluation.to_dict() for evaluation in evaluations]\n",
-        "output_json.parent.mkdir(parents=True, exist_ok=True)\n",
-        "output_json.write_text(json.dumps(payload, ensure_ascii=False, indent=2))\n",
-        "print(f\"Gespeicherte Bewertungen: {len(payload)}\")"
-      ]
+      "source": "tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME)\nmodel = AutoModelForCausalLM.from_pretrained(MODEL_NAME, device_map='auto', torch_dtype='auto')\ntext_generator = pipeline('text-generation', model=model, tokenizer=tokenizer, device_map='auto')"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": "## Run Evaluation"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": "evaluations = []\nfor _, claim_row in claims_df.iterrows():\n    base_name = claim_row['report'].split('.')[0]\n    matching = kpis_df[kpis_df['report'].str.contains(base_name, case=False, na=False)]\n    if matching.empty:\n        matching = kpis_df\n    for _, kpi_row in matching.iterrows():\n        prompt = build_prompt(claim_row, kpi_row)\n        response = text_generator(prompt, max_new_tokens=MAX_NEW_TOKENS, do_sample=False)[0]['generated_text']\n        evaluations.append({\n            'claim_report': claim_row['report'],\n            'kpi_report': kpi_row['report'],\n            'claim_text': claim_row['text'],\n            'kpis': kpi_row.to_dict(),\n            'llm_response': response,\n        })\n\nevaluations_df = pd.DataFrame(evaluations)\nevaluations_df.head()"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": "## Save Evaluations"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": "evaluations_df.to_csv('llm_evaluations.csv', index=False)"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": "The generated evaluations are stored in `llm_evaluations.csv` for further analysis."
     }
   ],
   "metadata": {


### PR DESCRIPTION
## Summary
- implement claim extraction notebook leveraging ClimateBERT for sustainability report analysis and CSV export
- add KPI extraction notebook parsing annual reports for key metrics and persisting results
- create LLM evaluation notebook orchestrating DeepSeek R1 Zero prompts to compare claims with KPIs and save outputs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d55b7f8800832f91b5c3497971cd8f