### PR TITLE
Add self-contained notebooks for claim, KPI, and LLM analysis

### DIFF
--- a/01_claim_extraction.ipynb
+++ b/01_claim_extraction.ipynb
@@ -3,84 +3,143 @@
     {
       "cell_type": "markdown",
       "metadata": {},
-      "source": "# Claim Extraction\n\nThis notebook extracts environmental claims from sustainability reports using the `climatebert/environmental-claims` model."
+      "source": [
+        "# Climate Claim Extraction mit ClimateBERT\n",
+        "\n",
+        "Dieses Notebook extrahiert in Nachhaltigkeitsberichten potentielle Green Claims und speichert sie zur weiteren Auswertung in einer CSV-Datei. Als Modell wird [`climatebert/environmental-claims`](https://huggingface.co/climatebert/environmental-claims) verwendet."
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {},
-      "source": "## Setup\n\nInstall the required libraries if they are not available in your environment."
+      "source": [
+        "## 1. Voraussetzungen\n",
+        "\n",
+        "Stelle sicher, dass die Python-Umgebung die in `requirements.txt` aufgeführten Pakete enthält. Für dieses Notebook werden insbesondere `transformers`, `torch`, `pandas` und `pdfplumber` benötigt."
+      ]
     },
     {
       "cell_type": "code",
       "metadata": {},
       "execution_count": null,
       "outputs": [],
-      "source": "%pip install -q transformers accelerate torch pdfplumber pandas tqdm"
+      "source": [
+        "from pathlib import Path\n",
+        "import re\n",
+        "from typing import Dict, List\n",
+        "\n",
+        "import pandas as pd\n",
+        "import pdfplumber\n",
+        "from transformers import AutoModelForSequenceClassification, AutoTokenizer, TextClassificationPipeline\n",
+        "\n",
+        "DATA_DIR = Path(\"data\")\n",
+        "DATA_DIR.mkdir(exist_ok=True)\n",
+        "\n",
+        "ESG_DIR = Path(\"ESG Reports\")\n",
+        "PDF_PATHS = sorted(ESG_DIR.glob(\"*.pdf\"))\n",
+        "PDF_PATHS"
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {},
-      "source": "## Imports"
+      "source": [
+        "## 2. Hilfsfunktionen\n",
+        "\n",
+        "Die folgenden Funktionen lesen PDF-Dateien ein, normalisieren den Text und zerlegen ihn in Sätze. Einfache Heuristiken (z. B. nach Punkten, Frage- und Ausrufezeichen) werden verwendet, um die Sätze zu bestimmen. Für wissenschaftliche Analysen empfiehlt sich, diese Vorverarbeitung bei Bedarf zu verfeinern."
+      ]
     },
     {
       "cell_type": "code",
       "metadata": {},
       "execution_count": null,
       "outputs": [],
-      "source": "import json\nfrom pathlib import Path\nfrom typing import Dict, List\n\nimport pandas as pd\nimport pdfplumber\nfrom tqdm.auto import tqdm\nfrom transformers import AutoModelForSequenceClassification, AutoTokenizer, pipeline"
+      "source": [
+        "sentence_split_regex = re.compile(r\"(?<=[.!?])\\s+(?=[A-ZÄÖÜ])\")\n",
+        "\n",
+        "def extract_sentences_from_pdf(path: Path) -> List[Dict[str, str]]:\n",
+        "    sentences = []\n",
+        "    with pdfplumber.open(path) as pdf:\n",
+        "        for page_number, page in enumerate(pdf.pages, start=1):\n",
+        "            text = page.extract_text() or \"\"\n",
+        "            text = re.sub(r\"\\s+\", \" \", text).strip()\n",
+        "            if not text:\n",
+        "                continue\n",
+        "            for sentence in sentence_split_regex.split(text):\n",
+        "                sentence = sentence.strip()\n",
+        "                if len(sentence) < 25:\n",
+        "                    continue\n",
+        "                sentences.append({\n",
+        "                    \"document_id\": path.name,\n",
+        "                    \"page\": page_number,\n",
+        "                    \"sentence\": sentence\n",
+        "                })\n",
+        "    return sentences\n",
+        "\n",
+        "sample_sentences = extract_sentences_from_pdf(PDF_PATHS[0]) if PDF_PATHS else []\n",
+        "len(sample_sentences), sample_sentences[:3]"
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {},
-      "source": "## Configuration\n\nAdjust the paths or thresholds below if needed."
+      "source": [
+        "## 3. Claim-Klassifikation mit ClimateBERT\n",
+        "\n",
+        "Das Modell liefert eine binäre Klassifikation (Claim vs. Non-Claim). Wir setzen eine Score-Schwelle von 0,5; alle Sätze mit höherem Score gelten als Claims. Die Schwelle kann je nach gewünschter Präzision/Recall angepasst werden."
+      ]
     },
     {
       "cell_type": "code",
       "metadata": {},
       "execution_count": null,
       "outputs": [],
-      "source": "ESG_REPORT_DIR = Path('ESG Reports')\nOUTPUT_CSV = Path('claims_extracted.csv')\nMODEL_NAME = 'climatebert/environmental-claims'\nMAX_TOKENS = 350\nSTRIDE = 50\nMIN_SCORE = 0.6"
+      "source": [
+        "model_name = \"climatebert/environmental-claims\"\n",
+        "\n",
+        "tokenizer = AutoTokenizer.from_pretrained(model_name)\n",
+        "model = AutoModelForSequenceClassification.from_pretrained(model_name)\n",
+        "claim_pipeline = TextClassificationPipeline(model=model, tokenizer=tokenizer, return_all_scores=False, device=-1)\n",
+        "\n",
+        "threshold = 0.5\n",
+        "records = []\n",
+        "for path in PDF_PATHS:\n",
+        "    for sentence_entry in extract_sentences_from_pdf(path):\n",
+        "        prediction = claim_pipeline(sentence_entry[\"sentence\"])\n",
+        "        label = prediction[0][\"label\"]\n",
+        "        score = float(prediction[0][\"score\"])\n",
+        "        is_claim = int(label.lower().endswith(\"claim\")) if \"claim\" in label.lower() else int(score >= threshold)\n",
+        "        if score >= threshold:\n",
+        "            records.append({\n",
+        "                **sentence_entry,\n",
+        "                \"label\": label,\n",
+        "                \"score\": score,\n",
+        "                \"is_claim\": is_claim\n",
+        "            })\n",
+        "\n",
+        "claims_df = pd.DataFrame.from_records(records)\n",
+        "claims_df.head()"
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {},
-      "source": "## Helper Functions"
+      "source": [
+        "## 4. Speicherung der Ergebnisse\n",
+        "\n",
+        "Die extrahierten Claims werden in einer CSV-Datei (`data/claims.csv`) abgelegt. Diese Datei dient als Eingabe für die KPI-Extraktion sowie das nachgelagerte LLM-Evaluationsnotebook."
+      ]
     },
     {
       "cell_type": "code",
       "metadata": {},
       "execution_count": null,
       "outputs": [],
-      "source": "def iter_pdf_text(pdf_path: Path) -> List[str]:\n    \"\"\"Extract cleaned text chunks from a PDF file.\"\"\"\n    paragraphs: List[str] = []\n    with pdfplumber.open(pdf_path) as pdf:\n        for page in pdf.pages:\n            text = page.extract_text(x_tolerance=1, y_tolerance=1) or ''\n            segments = [seg.strip() for seg in text.split('\\n') if seg.strip()]\n            paragraphs.extend(segments)\n    return paragraphs\n\n\ndef chunk_text(paragraphs: List[str], max_tokens: int, stride: int, tokenizer) -> List[Dict[str, str]]:\n    \"\"\"Chunk text into overlapping windows for the transformer model.\"\"\"\n    encoded = tokenizer(paragraphs, padding=False, truncation=False, add_special_tokens=False)\n    chunks: List[Dict[str, str]] = []\n    current_tokens: List[int] = []\n    current_texts: List[str] = []\n    for text, token_ids in zip(paragraphs, encoded['input_ids']):\n        if len(current_tokens) + len(token_ids) > max_tokens:\n            if current_tokens:\n                chunks.append({'text': ' '.join(current_texts)})\n                if stride > 0:\n                    stride_tokens = current_tokens[-stride:]\n                    stride_text = tokenizer.decode(stride_tokens, skip_special_tokens=True)\n                    current_tokens = list(stride_tokens)\n                    current_texts = [stride_text]\n                else:\n                    current_tokens = []\n                    current_texts = []\n        current_tokens.extend(token_ids)\n        current_texts.append(text)\n    if current_tokens:\n        chunks.append({'text': ' '.join(current_texts)})\n    return chunks"
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": "## Load Model"
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "execution_count": null,
-      "outputs": [],
-      "source": "tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME)\nmodel = AutoModelForSequenceClassification.from_pretrained(MODEL_NAME)\nclaim_classifier = pipeline('text-classification', model=model, tokenizer=tokenizer, top_k=None, truncation=True)"
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": "## Process Reports"
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "execution_count": null,
-      "outputs": [],
-      "source": "records = []\nfor pdf_path in sorted(ESG_REPORT_DIR.glob('*.pdf')):\n    paragraphs = iter_pdf_text(pdf_path)\n    chunks = chunk_text(paragraphs, max_tokens=MAX_TOKENS, stride=STRIDE, tokenizer=tokenizer)\n    for idx, chunk in enumerate(tqdm(chunks, desc=f'Processing {pdf_path.name}')):\n        text = chunk['text']\n        results = claim_classifier(text, truncation=True)\n        for result in results:\n            label = result['label']\n            score = float(result['score'])\n            if label.lower() == 'claim' and score >= MIN_SCORE:\n                records.append({\n                    'report': pdf_path.name,\n                    'chunk_id': idx,\n                    'text': text,\n                    'score': score,\n                })\n\nclaims_df = pd.DataFrame(records)\nclaims_df.to_csv(OUTPUT_CSV, index=False)\nclaims_df.head()"
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": "## Save and Inspect\n\nThe full set of extracted claims is stored in `claims_extracted.csv`."
+      "source": [
+        "claims_csv_path = DATA_DIR / \"claims.csv\"\n",
+        "claims_df.to_csv(claims_csv_path, index=False)\n",
+        "claims_csv_path"
+      ]
     }
   ],
   "metadata": {
@@ -91,7 +150,7 @@
     },
     "language_info": {
       "name": "python",
-      "version": "3.x"
+      "version": "3.10"
     }
   },
   "nbformat": 4,

--- a/02_kpi_extraction.ipynb
+++ b/02_kpi_extraction.ipynb
@@ -3,72 +3,141 @@
     {
       "cell_type": "markdown",
       "metadata": {},
-      "source": "# KPI Extraction\n\nThis notebook extracts financial KPIs from annual reports and stores the results in a CSV file."
+      "source": [
+        "# KPI-Extraktion aus Geschäftsberichten\n",
+        "\n",
+        "Dieses Notebook durchsucht Geschäftsberichte nach zentralen Nachhaltigkeits- und Emissionskennzahlen (KPIs). Die Ergebnisse werden in `data/kpis.csv` gespeichert und bilden die Datengrundlage für die LLM-Auswertung."
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {},
-      "source": "## Setup"
+      "source": [
+        "## 1. Setup\n",
+        "\n",
+        "Benötigte Pakete: `pandas`, `pdfplumber`, `regex`. Optional kann `tabula-py` ergänzt werden, wenn zusätzlich Tabellen extrahiert werden sollen."
+      ]
     },
     {
       "cell_type": "code",
       "metadata": {},
       "execution_count": null,
       "outputs": [],
-      "source": "%pip install -q pdfplumber pandas regex"
+      "source": [
+        "from pathlib import Path\n",
+        "import re\n",
+        "from typing import Dict, List\n",
+        "\n",
+        "import pandas as pd\n",
+        "import pdfplumber\n",
+        "\n",
+        "DATA_DIR = Path(\"data\")\n",
+        "DATA_DIR.mkdir(exist_ok=True)\n",
+        "\n",
+        "REPORT_DIR = Path(\"Annual Reports\")\n",
+        "REPORT_PATHS = sorted(REPORT_DIR.glob(\"*.pdf\"))\n",
+        "REPORT_PATHS"
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {},
-      "source": "## Imports"
+      "source": [
+        "## 2. KPI-Regeln\n",
+        "\n",
+        "Die Extraktion nutzt reguläre Ausdrücke, um häufige KPI-Formulierungen zu erkennen (z. B. `Scope 1 Emissions`, `Total CO2e`, `Renewable Energy Share`). Bei Bedarf können weitere Muster ergänzt werden."
+      ]
     },
     {
       "cell_type": "code",
       "metadata": {},
       "execution_count": null,
       "outputs": [],
-      "source": "import re\nfrom pathlib import Path\nfrom typing import Dict, List\n\nimport pandas as pd\nimport pdfplumber"
+      "source": [
+        "METRIC_PATTERNS = [\n",
+        "    (\"scope_1_emissions\", r\"(scope\\s*1[^0-9]{0,20})([0-9][0-9.,]*\\s*(?:t|tonnes|kt|mt)?\\s*(?:co2|co2e))\"),\n",
+        "    (\"scope_2_emissions\", r\"(scope\\s*2[^0-9]{0,20})([0-9][0-9.,]*\\s*(?:t|tonnes|kt|mt)?\\s*(?:co2|co2e))\"),\n",
+        "    (\"scope_3_emissions\", r\"(scope\\s*3[^0-9]{0,20})([0-9][0-9.,]*\\s*(?:t|tonnes|kt|mt)?\\s*(?:co2|co2e))\"),\n",
+        "    (\"total_emissions\", r\"(total[^\n]{0,40}emissions[^0-9]{0,20})([0-9][0-9.,]*\\s*(?:t|tonnes|kt|mt)?\\s*(?:co2|co2e))\"),\n",
+        "    (\"emission_reduction\", r\"(reduction[^\n]{0,40}emissions[^0-9]{0,20})([0-9][0-9.,]*\\s*% )\"),\n",
+        "    (\"renewable_energy_share\", r\"(renewable[^\n]{0,40}energy[^0-9]{0,20})([0-9][0-9.,]*\\s*%)\"),\n",
+        "]\n",
+        "\n",
+        "def clean_value(value: str) -> str:\n",
+        "    value = value.replace(' ', '')\n",
+        "    value = value.replace(',', '.') if value.count(',') == 1 and value.count('.') == 0 else value\n",
+        "    return value.strip()\n",
+        "\n",
+        "def extract_kpis_from_pdf(path: Path) -> List[Dict[str, str]]:\n",
+        "    entries: List[Dict[str, str]] = []\n",
+        "    with pdfplumber.open(path) as pdf:\n",
+        "        for page_number, page in enumerate(pdf.pages, start=1):\n",
+        "            raw_text = page.extract_text() or \"\"\n",
+        "            text = re.sub(r\"\\s+\", \" \" , raw_text)\n",
+        "            if not text.strip():\n",
+        "                continue\n",
+        "            lower_text = text.lower()\n",
+        "            for metric, pattern in METRIC_PATTERNS:\n",
+        "                for match in re.finditer(pattern, lower_text, flags=re.IGNORECASE):\n",
+        "                    context_span = match.span()\n",
+        "                    start = max(context_span[0] - 120, 0)\n",
+        "                    end = min(context_span[1] + 120, len(text))\n",
+        "                    context = text[start:end].strip()\n",
+        "                    entries.append({\n",
+        "                        \"document_id\": path.name,\n",
+        "                        \"page\": page_number,\n",
+        "                        \"metric\": metric,\n",
+        "                        \"value\": clean_value(match.group(2)),\n",
+        "                        \"context\": context\n",
+        "                    })\n",
+        "    return entries\n",
+        "\n",
+        "example_entries = extract_kpis_from_pdf(REPORT_PATHS[0]) if REPORT_PATHS else []\n",
+        "len(example_entries), example_entries[:3]"
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {},
-      "source": "## Configuration"
+      "source": [
+        "## 3. Verarbeitung aller Berichte\n",
+        "\n",
+        "Für jeden Geschäftsbericht werden die gefundenen KPIs gesammelt und in einem konsolidierten DataFrame abgelegt."
+      ]
     },
     {
       "cell_type": "code",
       "metadata": {},
       "execution_count": null,
       "outputs": [],
-      "source": "ANNUAL_REPORT_DIR = Path('Annual Reports')\nOUTPUT_CSV = Path('kpis_extracted.csv')\n\nKPI_PATTERNS = {\n    'revenue': r'(revenue|sales|turnover)[^0-9]+([0-9,.]+)',\n    'ebit': r'(ebit|operating profit)[^0-9]+([0-9,.]+)',\n    'net_income': r'(net income|profit attributable)[^0-9]+([0-9,.]+)',\n    'total_assets': r'(total assets)[^0-9]+([0-9,.]+)',\n    'scope_1_emissions': r'(scope\\s*1[^0-9]*emissions?)[^0-9]+([0-9,.]+)',\n    'scope_2_emissions': r'(scope\\s*2[^0-9]*emissions?)[^0-9]+([0-9,.]+)',\n}"
+      "source": [
+        "records: List[Dict[str, str]] = []\n",
+        "for path in REPORT_PATHS:\n",
+        "    records.extend(extract_kpis_from_pdf(path))\n",
+        "\n",
+        "kpi_df = pd.DataFrame.from_records(records)\n",
+        "kpi_df.head()"
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {},
-      "source": "## Helper Functions"
+      "source": [
+        "## 4. Export\n",
+        "\n",
+        "Die gewonnenen KPIs werden in `data/kpis.csv` gespeichert."
+      ]
     },
     {
       "cell_type": "code",
       "metadata": {},
       "execution_count": null,
       "outputs": [],
-      "source": "def extract_text_blocks(pdf_path: Path) -> List[str]:\n    blocks: List[str] = []\n    with pdfplumber.open(pdf_path) as pdf:\n        for page in pdf.pages:\n            text = page.extract_text(x_tolerance=1, y_tolerance=1) or ''\n            if text:\n                blocks.extend([line.strip() for line in text.split('\\n') if line.strip()])\n    return blocks\n\n\ndef find_kpis(blocks: List[str], patterns: Dict[str, str]) -> Dict[str, str]:\n    values: Dict[str, str] = {}\n    joined_text = '\\n'.join(blocks)\n    for kpi, pattern in patterns.items():\n        match = re.search(pattern, joined_text, flags=re.IGNORECASE)\n        if match:\n            values[kpi] = match.group(2).replace(',', '').strip()\n        else:\n            values[kpi] = ''\n    return values"
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": "## Process Reports"
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "execution_count": null,
-      "outputs": [],
-      "source": "records = []\nfor pdf_path in sorted(ANNUAL_REPORT_DIR.glob('*.pdf')):\n    blocks = extract_text_blocks(pdf_path)\n    kpi_values = find_kpis(blocks, KPI_PATTERNS)\n    kpi_values['report'] = pdf_path.name\n    records.append(kpi_values)\n\nkpis_df = pd.DataFrame(records)\nkpis_df.to_csv(OUTPUT_CSV, index=False)\nkpis_df.head()"
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": "## Save and Inspect\n\nThe full set of extracted KPIs is saved in `kpis_extracted.csv`."
+      "source": [
+        "kpis_csv_path = DATA_DIR / \"kpis.csv\"\n",
+        "kpi_df.to_csv(kpis_csv_path, index=False)\n",
+        "kpis_csv_path"
+      ]
     }
   ],
   "metadata": {
@@ -79,7 +148,7 @@
     },
     "language_info": {
       "name": "python",
-      "version": "3.x"
+      "version": "3.10"
     }
   },
   "nbformat": 4,

--- a/03_llm_evaluation.ipynb
+++ b/03_llm_evaluation.ipynb
@@ -3,108 +3,180 @@
     {
       "cell_type": "markdown",
       "metadata": {},
-      "source": "# LLM Evaluation for Greenwashing Detection\n\nThis notebook combines extracted claims and KPIs to prompt an LLM and identify potential inconsistencies."
+      "source": [
+        "# LLM-gestützte Konsistenzanalyse (DeepSeek R1 Zero)\n",
+        "\n",
+        "Dieses Notebook kombiniert die in den vorherigen Schritten extrahierten Claims (`data/claims.csv`) und KPIs (`data/kpis.csv`). Anschließend wird das offene Modell **DeepSeek R1 Zero** verwendet, um mögliche Widersprüche bzw. Greenwashing-Indikatoren zu bewerten."
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {},
-      "source": "## Setup"
+      "source": [
+        "## 1. Setup\n",
+        "\n",
+        "Das Notebook setzt auf `pandas` für die Datenverarbeitung sowie `transformers` und `torch` für das LLM. Stelle sicher, dass ausreichend GPU-Speicher zur Verfügung steht (das Modell umfasst mehrere Milliarden Parameter)."
+      ]
     },
     {
       "cell_type": "code",
       "metadata": {},
       "execution_count": null,
       "outputs": [],
-      "source": "%pip install -q transformers accelerate pandas"
+      "source": [
+        "import json\n",
+        "from pathlib import Path\n",
+        "from typing import Dict, List\n",
+        "\n",
+        "import pandas as pd\n",
+        "from transformers import AutoModelForCausalLM, AutoTokenizer, pipeline\n",
+        "import torch\n",
+        "\n",
+        "DATA_DIR = Path(\"data\")\n",
+        "claims_path = DATA_DIR / \"claims.csv\"\n",
+        "kpis_path = DATA_DIR / \"kpis.csv\"\n",
+        "\n",
+        "claims_df = pd.read_csv(claims_path)\n",
+        "kpis_df = pd.read_csv(kpis_path)\n",
+        "claims_df.head(), kpis_df.head()"
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {},
-      "source": "## Imports"
+      "source": [
+        "## 2. Kontextaufbereitung\n",
+        "\n",
+        "Pro Claim werden die thematisch nächstliegenden KPIs gesucht. Die Zuordnung basiert auf dem Dokumentnamen und der Seitennähe."
+      ]
     },
     {
       "cell_type": "code",
       "metadata": {},
       "execution_count": null,
       "outputs": [],
-      "source": "from pathlib import Path\nfrom typing import Dict\n\nimport pandas as pd\nfrom transformers import AutoModelForCausalLM, AutoTokenizer, pipeline"
+      "source": [
+        "def gather_kpis_for_claim(claim_row, max_kpis: int = 5) -> List[Dict[str, str]]:\n",
+        "    doc_kpis = kpis_df[kpis_df['document_id'] == claim_row['document_id']].copy()\n",
+        "    if doc_kpis.empty:\n",
+        "        return []\n",
+        "    doc_kpis['page_distance'] = (doc_kpis['page'] - claim_row['page']).abs()\n",
+        "    doc_kpis = doc_kpis.sort_values(['page_distance', 'metric'])\n",
+        "    return doc_kpis.head(max_kpis)[['metric', 'value', 'context', 'page']].to_dict(orient='records')\n",
+        "\n",
+        "sample_claim = claims_df.iloc[0] if not claims_df.empty else None\n",
+        "gather_kpis_for_claim(sample_claim) if sample_claim is not None else []"
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {},
-      "source": "## Configuration"
+      "source": [
+        "## 3. Prompt-Generierung\n",
+        "\n",
+        "Claims und KPIs werden zu einem strukturierten Prompt zusammengeführt. Der Prompt fordert das Modell auf, Konsistenz, mögliche Greenwashing-Indikatoren und eine Begründung zu liefern."
+      ]
     },
     {
       "cell_type": "code",
       "metadata": {},
       "execution_count": null,
       "outputs": [],
-      "source": "CLAIMS_CSV = Path('claims_extracted.csv')\nKPIS_CSV = Path('kpis_extracted.csv')\nMODEL_NAME = 'deepseek-ai/DeepSeek-R1-Zero'\nMAX_NEW_TOKENS = 512"
+      "source": [
+        "def build_prompt(claim: Dict[str, str], kpis: List[Dict[str, str]]) -> str:\n",
+        "    kpi_lines = []\n",
+        "    for idx, entry in enumerate(kpis, start=1):\n",
+        "        kpi_lines.append(f\"{idx}. Metric: {entry['metric']} | Value: {entry['value']} | Page: {entry['page']} | Context: {entry['context']}\")\n",
+        "    kpi_block = '\n'.join(kpi_lines) if kpi_lines else 'Keine zugehörigen KPIs gefunden.'\n",
+        "    prompt = f\"Du bist ein Analyst, der Nachhaltigkeitsbehauptungen mit Finanz- und Emissionskennzahlen abgleicht.\n\nClaim (Seite {claim['page']}): {claim['sentence']}\n\nRelevante KPIs:\n{kpi_block}\n\nAufgabe:\n1. Bewerte, ob der Claim durch die KPIs gestützt wird.\n2. Weisen auf mögliche Widersprüche oder Greenwashing-Risiken hin.\n3. Vergib eine Bewertung (Supported, Inconsistent, Unclear).\n4. Gib eine kurze Begründung und führe genutzte KPIs an.\n\nAntworte im JSON-Format mit den Schlüsseln `assessment`, `confidence` und `rationale`.\"\n        return prompt\n",
+        "\n",
+        "build_prompt(sample_claim, gather_kpis_for_claim(sample_claim)) if sample_claim is not None else ''"
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {},
-      "source": "## Load Data"
+      "source": [
+        "## 4. Laden des DeepSeek R1 Zero Modells\n",
+        "\n",
+        "Der folgende Abschnitt lädt das offene DeepSeek R1 Zero Modell. Passe ggf. `device_map` und `torch_dtype` an die verfügbare Hardware an. Für reine CPU-Ausführung kann `device_map=None` verwendet werden (deutlich langsamer)."
+      ]
     },
     {
       "cell_type": "code",
       "metadata": {},
       "execution_count": null,
       "outputs": [],
-      "source": "claims_df = pd.read_csv(CLAIMS_CSV)\nkpis_df = pd.read_csv(KPIS_CSV)\n\nclaims_df.head(), kpis_df.head()"
+      "source": [
+        "model_name = \"deepseek-ai/DeepSeek-R1-Zero\"\n",
+        "tokenizer = AutoTokenizer.from_pretrained(model_name)\n",
+        "model = AutoModelForCausalLM.from_pretrained(\n",
+        "    model_name,\n",
+        "    torch_dtype=torch.float16,\n",
+        "    device_map=\"auto\",\n",
+        ")\n",
+        "generation_pipeline = pipeline(\n",
+        "    \"text-generation\",\n",
+        "    model=model,\n",
+        "    tokenizer=tokenizer,\n",
+        "    max_new_tokens=512,\n",
+        "    temperature=0.1,\n",
+        "    do_sample=False\n",
+        ")"
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {},
-      "source": "## Prompt Construction"
+      "source": [
+        "## 5. Bewertung der Claims\n",
+        "\n",
+        "Für Demonstrationszwecke kann die Anzahl der Claims reduziert werden (z. B. `max_claims = 10`). Die Ergebnisse werden als JSON-Liste in `data/evaluations.json` gespeichert."
+      ]
     },
     {
       "cell_type": "code",
       "metadata": {},
       "execution_count": null,
       "outputs": [],
-      "source": "def build_prompt(claim_row: pd.Series, kpi_row: pd.Series) -> str:\n    claim_text = claim_row['text']\n    claim_score = claim_row.get('score', float('nan'))\n    kpi_values = kpi_row.drop(labels=['report']).to_dict()\n    kpi_lines = '\\n'.join(f\"- {name}: {value}\" for name, value in kpi_values.items() if value)\n    prompt = (\n        \"You are an ESG auditor. Analyse the sustainability claim against the financial indicators.\\n\\n\"\n        f\"Claim (confidence {claim_score:.2f}): {claim_text}\\n\\n\"\n        f\"Financial indicators from annual report:\\n{kpi_lines if kpi_lines else '- No KPIs found.'}\\n\\n\"\n        \"Assess whether the claim is supported by the KPIs, flag inconsistencies, and explain your reasoning.\"\n    )\n    return prompt"
+      "source": [
+        "max_claims = min(10, len(claims_df))\n",
+        "evaluations = []\n",
+        "for _, row in claims_df.head(max_claims).iterrows():\n",
+        "    kpis = gather_kpis_for_claim(row)\n",
+        "    prompt = build_prompt(row, kpis)\n",
+        "    response = generation_pipeline(prompt)[0]['generated_text']\n",
+        "    evaluations.append({\n",
+        "        \"document_id\": row['document_id'],\n",
+        "        \"claim_page\": int(row['page']),\n",
+        "        \"claim_text\": row['sentence'],\n",
+        "        \"kpis\": kpis,\n",
+        "        \"model_response\": response\n",
+        "    })\n",
+        "\n",
+        "evaluations[:2]"
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {},
-      "source": "## Load Model"
+      "source": [
+        "## 6. Export der Ergebnisse\n",
+        "\n",
+        "Die Modellantworten werden in einer JSON-Datei abgelegt, die für qualitative Auswertungen (z. B. manuelle Validierung oder Visualisierung) genutzt werden kann."
+      ]
     },
     {
       "cell_type": "code",
       "metadata": {},
       "execution_count": null,
       "outputs": [],
-      "source": "tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME)\nmodel = AutoModelForCausalLM.from_pretrained(MODEL_NAME, device_map='auto', torch_dtype='auto')\ntext_generator = pipeline('text-generation', model=model, tokenizer=tokenizer, device_map='auto')"
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": "## Run Evaluation"
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "execution_count": null,
-      "outputs": [],
-      "source": "evaluations = []\nfor _, claim_row in claims_df.iterrows():\n    base_name = claim_row['report'].split('.')[0]\n    matching = kpis_df[kpis_df['report'].str.contains(base_name, case=False, na=False)]\n    if matching.empty:\n        matching = kpis_df\n    for _, kpi_row in matching.iterrows():\n        prompt = build_prompt(claim_row, kpi_row)\n        response = text_generator(prompt, max_new_tokens=MAX_NEW_TOKENS, do_sample=False)[0]['generated_text']\n        evaluations.append({\n            'claim_report': claim_row['report'],\n            'kpi_report': kpi_row['report'],\n            'claim_text': claim_row['text'],\n            'kpis': kpi_row.to_dict(),\n            'llm_response': response,\n        })\n\nevaluations_df = pd.DataFrame(evaluations)\nevaluations_df.head()"
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": "## Save Evaluations"
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "execution_count": null,
-      "outputs": [],
-      "source": "evaluations_df.to_csv('llm_evaluations.csv', index=False)"
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": "The generated evaluations are stored in `llm_evaluations.csv` for further analysis."
+      "source": [
+        "evaluations_path = DATA_DIR / \"evaluations.json\"\n",
+        "with open(evaluations_path, 'w', encoding='utf-8') as f:\n",
+        "    json.dump(evaluations, f, ensure_ascii=False, indent=2)\n",
+        "evaluations_path"
+      ]
     }
   ],
   "metadata": {
@@ -115,7 +187,7 @@
     },
     "language_info": {
       "name": "python",
-      "version": "3.x"
+      "version": "3.10"
     }
   },
   "nbformat": 4,


### PR DESCRIPTION
## Summary
- rebuild the climate claim extraction notebook to load ESG PDFs, run climateBERT environmental-claims classification, and export detected statements to `data/claims.csv`
- add a self-contained KPI extraction notebook that parses annual reports with regex heuristics and stores structured metrics in `data/kpis.csv`
- create an LLM evaluation notebook that aligns claims with KPIs, prepares prompts, and runs DeepSeek R1 Zero to score potential greenwashing indicators

## Testing
- not run (notebooks only)

------
https://chatgpt.com/codex/tasks/task_e_68d56c4b3e94832f8640e75648c83c2d